### PR TITLE
new publishing method (Adds Surge and an `npm run deploy` script)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "> a community conference for all things npm, http://npm.github.io/npm-camp/",
   "main": "index.js",
   "scripts": {
-    "start": "live-server ./"
+    "start": "live-server ./",
+    "deploy": "surge ./"
   },
   "repository": {
     "type": "git",
@@ -18,7 +19,8 @@
   },
   "homepage": "https://github.com/npm/npm-camp#readme",
   "devDependencies": {
-    "live-server": "^0.9.0"
+    "live-server": "^0.9.0",
+    "surge": "0.17.7"
   },
   "dependencies": {
     "npm-styles": "^1.7.0"


### PR DESCRIPTION
Hey! Congrats on announcing this event, very exciting stuff.

Just something for your consideration, @sintaxi and I run [Surge.sh](https://surge.sh), static web publishing for front-end developers. Publishing happens right in the CLI through the `surge` npm package. This PR adds it this repo.

![1](https://cloud.githubusercontent.com/assets/1581276/12568095/1cb624ae-c378-11e5-97ed-2dea29bde834.gif)

I know you already have this deployed, so I understand if this isn’t helpful now, but if you’d like a more npm-y way of publishing, it’s an option. :) I believe some of npm’s static private module assets are already on Surge.

If you want to merge this PR:
- Here’s how you can [add your custom domain to Surge](https://surge.sh/help/adding-a-custom-domain)
- `npm run deploy` will deploy the site, and the `CNAME` file will be automatically recognised
- You can also set up [automatic deployment of the repo](https://surge.sh/help/integrating-with-travis-ci) via a CI service if you’d like

Regardless, looking forward to hearing more about the event.
